### PR TITLE
Functional Interface for Post Call Executions

### DIFF
--- a/src/main/java/org/kpull/apitestsuites/core/ApiCall.java
+++ b/src/main/java/org/kpull/apitestsuites/core/ApiCall.java
@@ -14,16 +14,16 @@ public class ApiCall {
     private ApiResponse response;
     private Class<?> responseModel;
     private Assertions<?> assertions;
-    private String postCallScript;
+    private PostCallExecution postCallExecution;
 
-    public ApiCall(String name, String description, ApiRequest request, ApiResponse response, Class<?> responseModel, Assertions<?> assertions, String postCallScript) {
+    public ApiCall(String name, String description, ApiRequest request, ApiResponse response, Class<?> responseModel, Assertions<?> assertions, PostCallExecution postCallExecution) {
         setName(name);
         setDescription(description);
         setRequest(request);
         setResponse(response);
         setResponseModel(responseModel);
         setAssertions(assertions);
-        setPostCallScript(postCallScript);
+        setPostCallExecution(postCallExecution);
     }
 
     public String getName() {
@@ -78,12 +78,11 @@ public class ApiCall {
         this.responseModel = responseModel;
     }
 
-    public String getPostCallScript() {
-        return postCallScript;
+    public PostCallExecution getPostCallExecution() {
+        return postCallExecution;
     }
 
-    public void setPostCallScript(String postCallScript) {
-        Objects.requireNonNull(postCallScript);
-        this.postCallScript = postCallScript;
+    public void setPostCallExecution(final PostCallExecution postCallExecution) {
+        this.postCallExecution = postCallExecution;
     }
 }

--- a/src/main/java/org/kpull/apitestsuites/core/ApiSuiteBuilder.java
+++ b/src/main/java/org/kpull/apitestsuites/core/ApiSuiteBuilder.java
@@ -71,7 +71,7 @@ public class ApiSuiteBuilder {
         private ApiResponse response = new ApiResponse(Collections.emptyList(), 0, "", "");
         private Class<?> responseModel = null;
         private Assertions<?> assertions = null;
-        private String postCallScript = "";
+        private PostCallExecution postCallExecution = null;
 
         private ApiCallBuilder() {
         }
@@ -88,16 +88,22 @@ public class ApiSuiteBuilder {
             return this;
         }
 
-        public ApiCallBuilder postCallScript(String postCallScript) {
-            Objects.requireNonNull(postCallScript);
-            this.postCallScript = postCallScript;
+        public ApiCallBuilder postCallExecution(final PostCallExecution postCallExecution) {
+            Objects.requireNonNull(postCallExecution);
+            this.postCallExecution = postCallExecution;
+            return this;
+        }
+
+        public ApiCallBuilder postCallScript(final String groovyScript) {
+            Objects.requireNonNull(groovyScript);
+            this.postCallExecution = new GroovyScriptPostCallExecution(groovyScript);
             return this;
         }
 
         public ApiCallBuilder postCallScriptFromFile(File postCallScript) {
             try {
                 Objects.requireNonNull(postCallScript);
-                this.postCallScript = FileUtils.readFileToString(postCallScript);
+                this.postCallExecution = new GroovyScriptPostCallExecution(FileUtils.readFileToString(postCallScript));
                 return this;
             } catch (IOException e) {
                 throw new IllegalStateException(format("Cannot open file: %s", postCallScript), e);
@@ -119,7 +125,7 @@ public class ApiSuiteBuilder {
         }
 
         public ApiSuiteBuilder done() {
-            apiCalls.add(new ApiCall(name, description, request, response, responseModel, assertions, postCallScript));
+            apiCalls.add(new ApiCall(name, description, request, response, responseModel, assertions, postCallExecution));
             return ApiSuiteBuilder.this;
         }
 

--- a/src/main/java/org/kpull/apitestsuites/core/GroovyScriptPostCallExecution.java
+++ b/src/main/java/org/kpull/apitestsuites/core/GroovyScriptPostCallExecution.java
@@ -1,0 +1,39 @@
+package org.kpull.apitestsuites.core;
+
+import com.google.common.base.Strings;
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
+import org.kpull.apitestsuites.runner.ExecutionContext;
+
+import java.util.Objects;
+
+/**
+ * @author <a href="mailto:mail@kylepullicino.com">Kyle</a>
+ */
+public class GroovyScriptPostCallExecution implements PostCallExecution {
+
+    private String groovyScript;
+
+    public GroovyScriptPostCallExecution(final String groovyScript) {
+        Objects.requireNonNull(groovyScript);
+        this.groovyScript = groovyScript;
+    }
+
+    @Override
+    public void execute(final ExecutionContext context, final ApiEnvironment environment) {
+        if (!Strings.isNullOrEmpty(groovyScript)) {
+            Binding binding = new Binding();
+            binding.setVariable("context", context);
+            binding.setVariable("apiCall", context.getCall());
+            binding.setVariable("apiRequest", context.getRequest());
+            binding.setVariable("httpRequest", context.getHttpRequest());
+            binding.setVariable("apiResponse", context.getCall().getResponse());
+            binding.setVariable("httpResponse", context.getHttpResponse());
+            binding.setVariable("jsonResponseBody", context.getJsonResponseBody());
+            binding.setVariable("model", context.getResponseModel());
+            binding.setVariable("environment", environment);
+            GroovyShell groovy = new GroovyShell(binding);
+            groovy.evaluate(groovyScript);
+        }
+    }
+}

--- a/src/main/java/org/kpull/apitestsuites/core/PostCallExecution.java
+++ b/src/main/java/org/kpull/apitestsuites/core/PostCallExecution.java
@@ -1,0 +1,12 @@
+package org.kpull.apitestsuites.core;
+
+import org.kpull.apitestsuites.runner.ExecutionContext;
+
+/**
+ * @author Francesco
+ */
+@FunctionalInterface
+public interface PostCallExecution {
+
+    void execute(ExecutionContext context, ApiEnvironment environment);
+}

--- a/src/main/java/org/kpull/apitestsuites/factory/RamlApiSuiteFactory.java
+++ b/src/main/java/org/kpull/apitestsuites/factory/RamlApiSuiteFactory.java
@@ -45,7 +45,7 @@ public class RamlApiSuiteFactory {
                 ActionType actionType = action.getKey();
                 Action actionContent = action.getValue();
                 String name = actionType.name() + " " + resourceContent.getRelativeUri();
-                ApiCall apiCall = new ApiCall(name, StringUtils.defaultString(actionContent.getDescription()), new ApiRequest(actionType.name(), resourceContent.getUri(), Collections.emptyList(), "application/json", "", Collections.emptyList()), new ApiResponse(Collections.emptyList(), 0, "", ""), null, null, "");
+                ApiCall apiCall = new ApiCall(name, StringUtils.defaultString(actionContent.getDescription()), new ApiRequest(actionType.name(), resourceContent.getUri(), Collections.emptyList(), "application/json", "", Collections.emptyList()), new ApiResponse(Collections.emptyList(), 0, "", ""), null, null, null);
                 apiCalls.add(apiCall);
             });
         });

--- a/src/main/java/org/kpull/apitestsuites/runner/ApiCallExecutor.java
+++ b/src/main/java/org/kpull/apitestsuites/runner/ApiCallExecutor.java
@@ -1,14 +1,11 @@
 package org.kpull.apitestsuites.runner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Strings;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import com.mashape.unirest.request.HttpRequest;
 import com.mashape.unirest.request.HttpRequestWithBody;
-import groovy.lang.Binding;
-import groovy.lang.GroovyShell;
 import org.apache.commons.lang.StringUtils;
 import org.kpull.apitestsuites.core.*;
 
@@ -87,19 +84,8 @@ public class ApiCallExecutor {
     }
 
     private void executePostCallScript() {
-        if (!Strings.isNullOrEmpty(apiCallToExecute.getPostCallScript())) {
-            Binding binding = new Binding();
-            binding.setVariable("context", context);
-            binding.setVariable("apiCall", context.getCall());
-            binding.setVariable("apiRequest", context.getRequest());
-            binding.setVariable("httpRequest", context.getHttpRequest());
-            binding.setVariable("apiResponse", context.getCall().getResponse());
-            binding.setVariable("httpResponse", context.getHttpResponse());
-            binding.setVariable("jsonResponseBody", context.getJsonResponseBody());
-            binding.setVariable("model", context.getResponseModel());
-            binding.setVariable("environment", environment);
-            GroovyShell groovy = new GroovyShell(binding);
-            groovy.evaluate(apiCallToExecute.getPostCallScript());
+        if (apiCallToExecute.getPostCallExecution() != null) {
+            apiCallToExecute.getPostCallExecution().execute(context, environment);
         }
     }
 

--- a/src/test/java/org/kpull/apitestsuites/junit/ApiSuiteRunnerTest.java
+++ b/src/test/java/org/kpull/apitestsuites/junit/ApiSuiteRunnerTest.java
@@ -32,10 +32,10 @@ public class ApiSuiteRunnerTest {
                         .done()
                     .responseModel(WeatherModel.class)
                         .assertions((statusCode, model, context) -> assertThat(model.getDt()).isNotEmpty())
-                    .postCallScript(
-                            "environment.putObject('lat', jsonResponseBody.get('coord').get('lat'));" +
-                            "System.out.println(model);"
-                    )
+                    .postCallExecution((context, environment) -> {
+                        context.getEnvironment().putObject("lat", context.getJsonResponseBody().get("coord").get("lat"));
+                        System.out.println(context.getResponseModel());
+                    })
                     .done()
                 .build();
         // @formatter:on


### PR DESCRIPTION
Updated the 'post call' execution for an API call to be compilable Java code via functional interfaces. An example of it in use can be seen in ApiSuiteRunnerTest.
